### PR TITLE
Add mutator endpoints for creates/updates

### DIFF
--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -1,6 +1,20 @@
-const { findAccount, createAccount, updatePassword } = require('../store/account');
-const { findCelebrity, createCelebrity } = require('../store/celebrity');
-const { findMedia, createMedia, addCelebrityToMedia } = require('../store/media');
+const { 
+    findAccount, 
+    createAccount, 
+    updatePassword 
+} = require('../store/account');
+const { 
+    findCelebrity, 
+    createCelebrity, 
+    addMediaToCelebrity, 
+    removeMediaFromCelebrity
+} = require('../store/celebrity');
+const { 
+    findMedia, 
+    createMedia, 
+    addCelebrityToMedia, 
+    removeCelebrityFromMedia 
+} = require('../store/media');
 
 const resolvers = {
     Query: {
@@ -41,18 +55,36 @@ const resolvers = {
                     user_name: input.user_name,
                     user_password: input.user_password
              })),
+
         updatePassword: ( _, { input }) =>
             updatePassword(input).then(() => ({
                     user_name: input.user_name,
                     user_password: input.user_password
             })),
+            
         createCelebrity: ( _, { input }) => 
             createCelebrity(input).then(() => input),
+
         createMedia: ( _, { input }) => 
             createMedia(input).then(() => input),
+
         addCelebrityToMedia: ( _, { link, fullname_native, dob}) =>
             addCelebrityToMedia(link, fullname_native, dob).then(() =>
-                findMedia({link: link}).then((res) => res[0]))
+                findMedia({link: link}).then((res) => res[0])),
+
+        removeCelebrityFromMedia: ( _, { link, fullname_native, dob}) =>
+            removeCelebrityFromMedia(link, fullname_native, dob).then(() =>
+                findMedia({link: link}).then((res) => res[0])),
+
+        addMediaToCelebrity: ( _, { link, fullname_native, dob}) =>
+            addMediaToCelebrity(fullname_native, dob, link).then(() =>
+                findCelebrity({fullname_native: fullname_native, dob: dob}).then((res) =>
+                    res[0])),
+
+        removeMediaFromCelebrity: ( _, { link, fullname_native, dob}) =>
+            removeMediaFromCelebrity(fullname_native, dob, link).then(() =>
+                findCelebrity({fullname_native: fullname_native, dob: dob}).then((res) =>
+                    res[0]))
     }
 };
 

--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -1,11 +1,29 @@
 const { findAccount, createAccount, updatePassword } = require('../store/account');
+const { findCelebrity, createCelebrity } = require('../store/celebrity');
+const { findMedia, createMedia } = require('../store/media');
 
 const resolvers = {
     Query: {
         accounts: ( _, { user_name } ) =>
             findAccount({ 
                 user_name: user_name 
-            })
+            }),
+        celebrity: ( _, args ) => 
+            findCelebrity(args),
+        media: ( _, args ) => 
+            findMedia(args)
+    },
+    Celebrity: {
+        appearances: ( { appearances } ) => 
+            Promise.all(appearances.map(val => findMedia(val))).then(res => 
+                res.map(val => ({...val[0],}));
+            )
+    },
+    Media: {
+        celebrities: ( { celebrities } ) => 
+            Promise.all(celebrities.map(val => findCelebrity(val))).then(res => 
+                res.map(val => ({...val[0],}));
+            )
     },
     Mutation: {
         createAccount: ( _, { input }) => 
@@ -17,7 +35,11 @@ const resolvers = {
             updatePassword(input).then(() => ({
                     user_name: input.user_name,
                     user_password: input.user_password
-            }))
+            })),
+        createCelebrity: ( _, { input }) => 
+            createCelebrity(input).then(() => input),
+        createMedia: ( _, { input }) => 
+            createMedia(input).then(() => input)
     }
 };
 

--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -1,6 +1,6 @@
 const { findAccount, createAccount, updatePassword } = require('../store/account');
 const { findCelebrity, createCelebrity } = require('../store/celebrity');
-const { findMedia, createMedia } = require('../store/media');
+const { findMedia, createMedia, addCelebrityToMedia } = require('../store/media');
 
 const resolvers = {
     Query: {
@@ -14,16 +14,26 @@ const resolvers = {
             findMedia(args)
     },
     Celebrity: {
-        appearances: ( { appearances } ) => 
-            Promise.all(appearances.map(val => findMedia(val))).then(res => 
-                res.map(val => ({...val[0],}));
-            )
+        appearances: ( { appearances } ) => {
+            if(appearances) {
+                return Promise.all(appearances.map(val => findMedia(val))).then(res => {
+                    if (res) {
+                        return res.map(val => ({...val[0],}));
+                    }
+                })
+            }
+        }
     },
     Media: {
-        celebrities: ( { celebrities } ) => 
-            Promise.all(celebrities.map(val => findCelebrity(val))).then(res => 
-                res.map(val => ({...val[0],}));
-            )
+        celebrities: ( { celebrities } ) => {
+            if(celebrities) {
+                return Promise.all(celebrities.map(val => findCelebrity(val))).then(res => { 
+                    if(res) {
+                        return res.map(val => ({...val[0],}));
+                    }
+                })
+            }
+        }
     },
     Mutation: {
         createAccount: ( _, { input }) => 
@@ -39,7 +49,10 @@ const resolvers = {
         createCelebrity: ( _, { input }) => 
             createCelebrity(input).then(() => input),
         createMedia: ( _, { input }) => 
-            createMedia(input).then(() => input)
+            createMedia(input).then(() => input),
+        addCelebrityToMedia: ( _, { link, fullname_native, dob}) =>
+            addCelebrityToMedia(link, fullname_native, dob).then(() =>
+                findMedia({link: link}).then((res) => res[0]))
     }
 };
 

--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -1,8 +1,9 @@
 const { 
-    findAccount, 
+    findAccount,
     createAccount, 
     updatePassword 
 } = require('../store/account');
+
 const { 
     findCelebrity, 
     createCelebrity, 
@@ -19,9 +20,7 @@ const {
 const resolvers = {
     Query: {
         accounts: ( _, { user_name } ) =>
-            findAccount({ 
-                user_name: user_name 
-            }),
+            findAccount({ user_name }),
         celebrity: ( _, args ) => 
             findCelebrity(args),
         media: ( _, args ) => 
@@ -29,38 +28,37 @@ const resolvers = {
     },
     Celebrity: {
         appearances: ( { appearances } ) => {
-            if(appearances) {
-                return Promise.all(appearances.map(val => findMedia(val))).then(res => {
-                    if (res) {
-                        return res.map(val => ({...val[0],}));
-                    }
-                })
+            if(!appearances) {
+                return [];
             }
+            return Promise.all(appearances.map(val => findMedia(val))).then(res => {
+                if (!res) {
+                    return [];
+                }
+                return res.map(val => ({...val[0],}));
+            })
         }
     },
     Media: {
         celebrities: ( { celebrities } ) => {
-            if(celebrities) {
-                return Promise.all(celebrities.map(val => findCelebrity(val))).then(res => { 
-                    if(res) {
-                        return res.map(val => ({...val[0],}));
-                    }
-                })
+            if(!celebrities) {
+                return [];
             }
+            return Promise.all(celebrities.map(val => findCelebrity(val))).then(res => { 
+                if(!res) {
+                    return [];
+                }
+                    return res.map(val => ({...val[0],}));        
+            })
+            
         }
     },
     Mutation: {
         createAccount: ( _, { input }) => 
-            createAccount(input).then(() => ({
-                    user_name: input.user_name,
-                    user_password: input.user_password
-             })),
+            createAccount(input).then(() => input),
 
         updatePassword: ( _, { input }) =>
-            updatePassword(input).then(() => ({
-                    user_name: input.user_name,
-                    user_password: input.user_password
-            })),
+            updatePassword(input).then(() => input),
             
         createCelebrity: ( _, { input }) => 
             createCelebrity(input).then(() => input),

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -1,28 +1,14 @@
 const typeDefs = `
 
-    enum Gender {
-      male
-      female
-    }
-
-    enum Category {
-        interview
-        talk_show
-        commercial
-        variety_show
-        music_show
-        radio_show
-        television
-        movie
-        vlive
-        misc
-    }
-
     type Query {
         accounts(user_name: String): [Account]
-        celebrity(id: ID, 
-                  name: String, 
-                  gender: Gender,
+        celebrity(id: ID,
+                  firstname: String, 
+                  lastname: String,
+                  firstname_birth: String,
+                  lastname_birth: String,
+                  fullname_native: String,
+                  gender: String,
                   occupation: String,
                   nationality: String,
                   dob: String): [Celebrity]
@@ -30,7 +16,7 @@ const typeDefs = `
               name: String,
               description: String,
               link: String,
-              category: Category): [Media]
+              category: String): [Media]
     }
     
     type Account {
@@ -40,8 +26,12 @@ const typeDefs = `
 
     type Celebrity {
         id: ID,
-        name: String!,
-        gender: Gender,
+        firstname: String!, 
+        lastname: String!,
+        firstname_birth: String!,
+        lastname_birth: String!,
+        fullname_native: String!,
+        gender: String,
         occupation: String,
         nationality: String,
         dob: String,
@@ -53,7 +43,7 @@ const typeDefs = `
         name: String!,
         description: String,
         link: String!,
-        category: Category,
+        category: String,
         celebrities: [Celebrity]
     }
 
@@ -64,12 +54,15 @@ const typeDefs = `
 
     input CelebrityInput {
         id: ID,
-        name: String!,
+        firstname: String!, 
+        lastname: String!,
+        firstname_birth: String!,
+        lastname_birth: String!,
+        fullname_native: String!,
         gender: String,
         occupation: String,
         nationality: String,
-        dob: String,
-        appearances: [MediaInput]
+        dob: String
     }
 
     input MediaInput {
@@ -77,18 +70,16 @@ const typeDefs = `
         name: String!,
         description: String,
         link: String!,
-        category: Category,
-        celebrities: [CelebrityInput]
+        category: String
     }
 
     # Allow mutations
     type Mutation {
         createAccount(input: AccountInput): Account
         updatePassword(input: AccountInput): Account
-
         createCelebrity(input: CelebrityInput): Celebrity
-
         createMedia(input: MediaInput): Media
+        addCelebrityToMedia(link: String!, fullname_native: String!, dob: String!): Media
     }
 `;
 

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -1,6 +1,36 @@
 const typeDefs = `
+
+    enum Gender {
+      male
+      female
+    }
+
+    enum Category {
+        interview
+        talk_show
+        commercial
+        variety_show
+        music_show
+        radio_show
+        television
+        movie
+        vlive
+        misc
+    }
+
     type Query {
         accounts(user_name: String): [Account]
+        celebrity(id: ID, 
+                  name: String, 
+                  gender: Gender,
+                  occupation: String,
+                  nationality: String,
+                  dob: String): [Celebrity]
+        media(id: ID,
+              name: String,
+              description: String,
+              link: String,
+              category: Category): [Media]
     }
     
     type Account {
@@ -8,15 +38,57 @@ const typeDefs = `
         user_password: String
     }
 
+    type Celebrity {
+        id: ID,
+        name: String!,
+        gender: Gender,
+        occupation: String,
+        nationality: String,
+        dob: String,
+        appearances: [Media]
+    }
+
+    type Media {
+        id: ID,
+        name: String!,
+        description: String,
+        link: String!,
+        category: Category,
+        celebrities: [Celebrity]
+    }
+
     input AccountInput {
         user_name: String!,
         user_password: String!
+    }
+
+    input CelebrityInput {
+        id: ID,
+        name: String!,
+        gender: String,
+        occupation: String,
+        nationality: String,
+        dob: String,
+        appearances: [MediaInput]
+    }
+
+    input MediaInput {
+        id: ID,
+        name: String!,
+        description: String,
+        link: String!,
+        category: Category,
+        celebrities: [CelebrityInput]
     }
 
     # Allow mutations
     type Mutation {
         createAccount(input: AccountInput): Account
         updatePassword(input: AccountInput): Account
+
+        createCelebrity(input: CelebrityInput): Celebrity
+
+        createMedia(input: MediaInput): Media
     }
 `;
 

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -80,6 +80,9 @@ const typeDefs = `
         createCelebrity(input: CelebrityInput): Celebrity
         createMedia(input: MediaInput): Media
         addCelebrityToMedia(link: String!, fullname_native: String!, dob: String!): Media
+        addMediaToCelebrity(fullname_native: String!, dob: String!, link: String!): Celebrity
+        removeMediaFromCelebrity(fullname_native: String!, dob: String!, link: String!): Celebrity
+        removeCelebrityFromMedia(link: String!, fullname_native: String!, dob: String!): Media
     }
 `;
 

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -3,40 +3,22 @@ CREATE TABLE IF NOT EXISTS accounts (
   user_password varchar(256)
 );
 
+
 CREATE TABLE IF NOT EXISTS celebrity (
   id serial PRIMARY KEY,
   name varchar(64),
+  gender varchar(12),
   occupation varchar(32),
   nationality varchar(32),
   dob date,
   appearances jsonb
 );
 
-
-/* Define category enum */ 
-DO $$
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'categories') THEN
-        CREATE TYPE categories as ENUM (
-          'interview',
-          'talk show',
-          'commercial',
-          'variety show',
-          'music show',
-          'television',
-          'movie',
-          'vlive',
-          'radio show',
-          'misc'
-        );
-    END IF;
-END$$;
-
 CREATE TABLE IF NOT EXISTS media (
   id serial PRIMARY KEY,
   name varchar(128),
   description varchar(128),
   link varchar(256),
-  category categories,
+  category varchar(16),
   celebrities jsonb
 );

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -3,22 +3,47 @@ CREATE TABLE IF NOT EXISTS accounts (
   user_password varchar(256)
 );
 
+/* Define category enum */ 
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'categories') THEN
+        CREATE TYPE categories as ENUM (
+          'interview',
+          'talk show',
+          'commercial',
+          'variety show',
+          'music show',
+          'television',
+          'movie',
+          'vlive',
+          'radio show',
+          'misc'
+        );
+    END IF;
+END$$;
+
 
 CREATE TABLE IF NOT EXISTS celebrity (
-  id serial PRIMARY KEY,
-  name varchar(64),
+  id serial PRIMARY KEY, 
+  firstname varchar(16),
+  lastname varchar(16),
+  firstname_birth varchar(16),
+  lastname_birth varchar(16),
+  fullname_native varchar(32),
   gender varchar(12),
   occupation varchar(32),
   nationality varchar(32),
   dob date,
-  appearances jsonb
+  appearances jsonb,
+  unique (fullname_native, dob)
 );
+
 
 CREATE TABLE IF NOT EXISTS media (
   id serial PRIMARY KEY,
   name varchar(128),
   description varchar(128),
-  link varchar(256),
-  category varchar(16),
+  link varchar(256) unique,
+  category categories,
   celebrities jsonb
 );

--- a/store/account.js
+++ b/store/account.js
@@ -5,11 +5,11 @@ const db = require('./db');
  * @param search - object for where parameter of query
  */
 function findAccount(search) {
-    if(typeof search != 'undefined') {
-        return db.select().from('accounts').where(search); 
+    if(!search) {
+        return db.select().from('account');
     } else {
-        return db.select().from('accounts');
-    }
+        return db.select().from('accounts').where(search); 
+    } 
 }
 
 /**

--- a/store/account.js
+++ b/store/account.js
@@ -5,7 +5,7 @@ const db = require('./db');
  * @param search - object for where parameter of query
  */
 function findAccount(search) {
-    if(typeof search.user_name != 'undefined') {
+    if(typeof search != 'undefined') {
         return db.select().from('accounts').where(search); 
     } else {
         return db.select().from('accounts');

--- a/store/celebrity.js
+++ b/store/celebrity.js
@@ -1,5 +1,4 @@
 const db = require('./db');
-const { findMedia, createMedia } = require('./media');
 
 /**
  * @param db - database object
@@ -17,15 +16,7 @@ function findCelebrity(search) {
  * @param details - celebrity object to create 
  */
 function createCelebrity(details) {
-    if(typeof details.appearances != 'undefined') {
-        return createMedia(details.appearances).then(() => 
-            Promise.all(details.appearances.map(val => findMedia(val))).then((res) => {
-                details.appearances = JSON.stringify(res.map(val => ({'id': val[0].id.toString()})));
-                return db.insert(details).into('celebrity');
-            }))
-    } else {
-        return db.insert(details).into('celebrity');
-    }
+    return db.insert(details).into('celebrity');
 }
 
 

--- a/store/celebrity.js
+++ b/store/celebrity.js
@@ -1,0 +1,32 @@
+const db = require('./db');
+const { findMedia, createMedia } = require('./media');
+
+/**
+ * @param db - database object
+ * @param search - object for where parameter of query
+ */
+function findCelebrity(search) {
+    if(typeof search != 'undefined') {
+        return db.select().from('celebrity').where(search); 
+    } else {
+        return db.select().from('celebrity');
+    }
+}
+
+/**
+ * @param details - celebrity object to create 
+ */
+function createCelebrity(details) {
+    if(typeof details.appearances != 'undefined') {
+        return createMedia(details.appearances).then(() => 
+            Promise.all(details.appearances.map(val => findMedia(val))).then((res) => {
+                details.appearances = JSON.stringify(res.map(val => ({'id': val[0].id.toString()})));
+                return db.insert(details).into('celebrity');
+            }))
+    } else {
+        return db.insert(details).into('celebrity');
+    }
+}
+
+
+module.exports = { findCelebrity, createCelebrity };

--- a/store/celebrity.js
+++ b/store/celebrity.js
@@ -19,5 +19,81 @@ function createCelebrity(details) {
     return db.insert(details).into('celebrity');
 }
 
+/**
+ * Add media item to appearances field of a celebrity
+ * @param fullname_native - used with dob to form unique index to fetch celebrity ID
+ * @param dob - ^ 
+ * @param link - link to the unique media object
+ */
+function addMediaToCelebrity(fullname_native, dob, link) {
 
-module.exports = { findCelebrity, createCelebrity };
+    // first fetch the media item with link as unique index
+    return db.select().first().from('media').where({
+        link: link
+    }).then(({ id }) => {
+        var unique_index = {fullname_native: fullname_native, dob: dob};
+
+        // then fetch the celebrity item with name + dob as unique index
+        return db.select().first().from('celebrity').where(unique_index).then((res) => {
+            if(res.appearances) {
+
+                // check to see if our media Id already exists
+                var occurs = false;
+                for(var k in res.appearances) {
+                    if(res.appearances[k].id == id) {
+                      occurs = true;
+                    }
+                }
+
+                // if it doesn't, push a new element to our json array
+                if(!occurs) {
+                    res.appearances.push({'id': id.toString()});
+                    return db.from('celebrity').where(unique_index).update({
+                        appearances: JSON.stringify(res.appearances)
+                    });
+                }
+            } else {
+                // if appearances field is undefined, create a new json array and update
+                res.appearances = [{'id': id.toString()}];
+                return db.from('celebrity').where(unique_index).update({
+                    appearances: JSON.stringify(res.appearances)
+                });
+            }
+        });
+    });
+}
+
+
+/**
+ * Remove media from appearances field of a celebrity
+ * @param fullname_native - used with dob to form unique index to fetch celebrity ID
+ * @param dob - ^ 
+ * @param link - link to the unique media object
+ */
+function removeMediaFromCelebrity(fullname_native, dob, link) {
+
+    // first fetch the media item with our unique index
+    return db.select().first().from('media').where({
+        link: link
+    }).then(({ id }) => {
+        var unique_index = {fullname_native: fullname_native, dob: dob};
+
+        // then fetch the celebrity item with name + dob as unique index
+        return db.select().first().from('celebrity').where(unique_index).then((res) => {
+            if(res.appearances) {
+
+                // delete media by id in json array (if it exists)
+                for(var k in res.appearances) {
+                    if(res.appearances[k].id == id) {
+                        res.appearances.splice(k, 1);
+                        return db.from('celebrity').where(unique_index).update({
+                            appearances: JSON.stringify(res.appearances)
+                        });
+                    }
+                }
+            } 
+        });
+    });
+}
+
+module.exports = { findCelebrity, createCelebrity, addMediaToCelebrity, removeMediaFromCelebrity };

--- a/store/celebrity.js
+++ b/store/celebrity.js
@@ -37,16 +37,8 @@ function addMediaToCelebrity(fullname_native, dob, link) {
         return db.select().first().from('celebrity').where(unique_index).then((res) => {
             if(res.appearances) {
 
-                // check to see if our media Id already exists
-                var occurs = false;
-                for(var k in res.appearances) {
-                    if(res.appearances[k].id == id) {
-                      occurs = true;
-                    }
-                }
-
-                // if it doesn't, push a new element to our json array
-                if(!occurs) {
+                // if a media item doesn't exist, push a new element to json array
+                if(!res.appearances.map(val => val.id).includes(id)) {
                     res.appearances.push({'id': id.toString()});
                     return db.from('celebrity').where(unique_index).update({
                         appearances: JSON.stringify(res.appearances)
@@ -82,15 +74,12 @@ function removeMediaFromCelebrity(fullname_native, dob, link) {
         return db.select().first().from('celebrity').where(unique_index).then((res) => {
             if(res.appearances) {
 
+                res.appearances = res.appearances.filter(val => val.id != id);
+
                 // delete media by id in json array (if it exists)
-                for(var k in res.appearances) {
-                    if(res.appearances[k].id == id) {
-                        res.appearances.splice(k, 1);
-                        return db.from('celebrity').where(unique_index).update({
-                            appearances: JSON.stringify(res.appearances)
-                        });
-                    }
-                }
+                return db.from('celebrity').where(unique_index).update({
+                    appearances: JSON.stringify(res.appearances)
+                });
             } 
         });
     });

--- a/store/celebrity.js
+++ b/store/celebrity.js
@@ -5,10 +5,10 @@ const db = require('./db');
  * @param search - object for where parameter of query
  */
 function findCelebrity(search) {
-    if(typeof search != 'undefined') {
-        return db.select().from('celebrity').where(search); 
+    if(!search) {
+        return db.select().from('celebrity'); 
     } else {
-        return db.select().from('celebrity');
+        return db.select().from('celebrity').where(search);
     }
 }
 

--- a/store/media.js
+++ b/store/media.js
@@ -1,5 +1,4 @@
 const db = require('./db');
-const { findCelebrity, createCelebrity } = require('./celebrity');
 
 /**
  * @param db - database object
@@ -7,7 +6,7 @@ const { findCelebrity, createCelebrity } = require('./celebrity');
  */
 function findMedia(search) {
     if(typeof search != 'undefined') {
-        return db.select().from('media').where(search); 
+        return db.select().from('media').where(search);
     } else {
         return db.select().from('media');
     }
@@ -17,15 +16,51 @@ function findMedia(search) {
  * @param details - media object to create 
  */
 function createMedia(details) {
-    if(typeof details.celebrities != 'undefined') {
-        return createCelebrity(details.celebrities).then(() => 
-            Promise.all(details.celebrities.map(val => findCelebrity(val))).then((res) => {
-                details.celebrities = JSON.stringify(res.map(val => ({'id': val[0].id.toString()})));
-                return db.insert(details).into('celebrity');
-            }))
-    } else {
-        return db.insert(details).into('media');
-    }
+    return db.insert(details).into('media');
 }
 
-module.exports = { findMedia, createMedia };
+/**
+ * @param link - link to the unique media object
+ * @param fullname_native - used with dob to form unique constraint to fetch celebrity ID
+ * @param dob - ^ 
+ */
+function addCelebrityToMedia(link, fullname_native, dob) {
+
+    // first fetch the celebrity item with unique constraint
+    return db.select().first().from('celebrity').where({
+      fullname_native: fullname_native,
+      dob: dob
+    }).then(({ id }) => {
+
+      // then fetch the media item with link as the unique constraint
+      return db.select().first().from('media').where({link: link}).then((res) => {
+        if(res.celebrities) {
+
+          // check to see if our celebrity Id already exists 
+          var occurs = false;
+          for(var k in res.celebrities) {
+            if(res.celebrities[k].id == id) {
+              occurs = true;
+            }
+          }
+
+          // if it doesn't, push a new element to our json array
+          if(!occurs) {
+            res.celebrities.push({'id': id.toString()});
+            return db.from('media').where({link: link}).update({
+              celebrities: JSON.stringify(res.celebrities)
+            });
+          }
+        } else {
+          // if celebrities field is undefined, create a new json array and update
+          res.celebrities = [{'id': id.toString()}];
+          return db.from('media').where({link: link}).update({
+            celebrities: JSON.stringify(res.celebrities)
+          });
+        }
+      });
+    });
+}
+
+
+module.exports = { findMedia, createMedia, addCelebrityToMedia };

--- a/store/media.js
+++ b/store/media.js
@@ -1,0 +1,31 @@
+const db = require('./db');
+const { findCelebrity, createCelebrity } = require('./celebrity');
+
+/**
+ * @param db - database object
+ * @param search - object for where parameter of query
+ */
+function findMedia(search) {
+    if(typeof search != 'undefined') {
+        return db.select().from('media').where(search); 
+    } else {
+        return db.select().from('media');
+    }
+}
+
+/**
+ * @param details - media object to create 
+ */
+function createMedia(details) {
+    if(typeof details.celebrities != 'undefined') {
+        return createCelebrity(details.celebrities).then(() => 
+            Promise.all(details.celebrities.map(val => findCelebrity(val))).then((res) => {
+                details.celebrities = JSON.stringify(res.map(val => ({'id': val[0].id.toString()})));
+                return db.insert(details).into('celebrity');
+            }))
+    } else {
+        return db.insert(details).into('media');
+    }
+}
+
+module.exports = { findMedia, createMedia };

--- a/store/media.js
+++ b/store/media.js
@@ -26,41 +26,73 @@ function createMedia(details) {
  */
 function addCelebrityToMedia(link, fullname_native, dob) {
 
-    // first fetch the celebrity item with unique constraint
+    // first fetch the celebrity item with unique index
     return db.select().first().from('celebrity').where({
-      fullname_native: fullname_native,
-      dob: dob
+        fullname_native: fullname_native,
+        dob: dob
     }).then(({ id }) => {
 
-      // then fetch the media item with link as the unique constraint
-      return db.select().first().from('media').where({link: link}).then((res) => {
-        if(res.celebrities) {
+        // then fetch the media item with link as the unique index
+        return db.select().first().from('media').where({link: link}).then((res) => {
+            if(res.celebrities) {
 
-          // check to see if our celebrity Id already exists 
-          var occurs = false;
-          for(var k in res.celebrities) {
-            if(res.celebrities[k].id == id) {
-              occurs = true;
+                // check to see if our celebrity Id already exists 
+                var occurs = false;
+                for(var k in res.celebrities) {
+                    if(res.celebrities[k].id == id) {
+                      occurs = true;
+                    }
+                }
+
+                // if it doesn't, push a new element to our json array
+                if(!occurs) {
+                    res.celebrities.push({'id': id.toString()});
+                    return db.from('media').where({link: link}).update({
+                        celebrities: JSON.stringify(res.celebrities)
+                    });
+                }
+            } else {
+                // if celebrities field is undefined, create a new json array and update
+                res.celebrities = [{'id': id.toString()}];
+                return db.from('media').where({link: link}).update({
+                    celebrities: JSON.stringify(res.celebrities)
+                });
             }
-          }
+        });
+    });
+}
 
-          // if it doesn't, push a new element to our json array
-          if(!occurs) {
-            res.celebrities.push({'id': id.toString()});
-            return db.from('media').where({link: link}).update({
-              celebrities: JSON.stringify(res.celebrities)
-            });
-          }
-        } else {
-          // if celebrities field is undefined, create a new json array and update
-          res.celebrities = [{'id': id.toString()}];
-          return db.from('media').where({link: link}).update({
-            celebrities: JSON.stringify(res.celebrities)
-          });
-        }
-      });
+/**
+ * Remove celebrity from the celebrities field of a media item
+ * @param link - link to the unique media object
+ * @param fullname_native - used with dob to form unique index to fetch celebrity ID
+ * @param dob - ^ 
+ */
+function removeCelebrityFromMedia(link, fullname_native, dob) {
+
+    // first fetch the celebrity item with our unique index
+    return db.select().first().from('celebrity').where({
+        fullname_native: fullname_native,
+        dob: dob
+    }).then(({ id }) => {
+
+        // then fetch the media item with link as unique index
+        return db.select().first().from('media').where({link: link}).then((res) => {
+            if(res.celebrities) {
+
+                // delete media by id in json array (if it exists)
+                for(var k in res.celebrities) {
+                    if(res.celebrities[k].id == id) {
+                        res.celebrities.splice(k, 1);
+                        return db.from('media').where({link: link}).update({
+                            celebrities: JSON.stringify(res.celebrities)
+                        });
+                    }
+                }
+            } 
+        });
     });
 }
 
 
-module.exports = { findMedia, createMedia, addCelebrityToMedia };
+module.exports = { findMedia, createMedia, addCelebrityToMedia, removeCelebrityFromMedia };

--- a/store/media.js
+++ b/store/media.js
@@ -36,16 +36,8 @@ function addCelebrityToMedia(link, fullname_native, dob) {
         return db.select().first().from('media').where({link: link}).then((res) => {
             if(res.celebrities) {
 
-                // check to see if our celebrity Id already exists 
-                var occurs = false;
-                for(var k in res.celebrities) {
-                    if(res.celebrities[k].id == id) {
-                      occurs = true;
-                    }
-                }
-
-                // if it doesn't, push a new element to our json array
-                if(!occurs) {
+                // if celebrity item doesnt exist, add a new element to our json array
+                if(!res.appearances.map(val => val.id).includes(id)) {
                     res.celebrities.push({'id': id.toString()});
                     return db.from('media').where({link: link}).update({
                         celebrities: JSON.stringify(res.celebrities)
@@ -80,15 +72,12 @@ function removeCelebrityFromMedia(link, fullname_native, dob) {
         return db.select().first().from('media').where({link: link}).then((res) => {
             if(res.celebrities) {
 
+                res.celebrities = res.appearances.filter(val => val.id != id);
+
                 // delete media by id in json array (if it exists)
-                for(var k in res.celebrities) {
-                    if(res.celebrities[k].id == id) {
-                        res.celebrities.splice(k, 1);
-                        return db.from('media').where({link: link}).update({
+                return db.from('media').where({link: link}).update({
                             celebrities: JSON.stringify(res.celebrities)
-                        });
-                    }
-                }
+                });
             } 
         });
     });

--- a/store/media.js
+++ b/store/media.js
@@ -5,10 +5,10 @@ const db = require('./db');
  * @param search - object for where parameter of query
  */
 function findMedia(search) {
-    if(typeof search != 'undefined') {
-        return db.select().from('media').where(search);
-    } else {
+    if(!search) {
         return db.select().from('media');
+    } else {
+        return db.select().from('media').where(search);
     }
 }
 


### PR DESCRIPTION
- Change postgres schema to use three name forms for the celebrity table and unique constraints on `fullname_native + dob` for the `celebrity` table and `link` for the `media` table

Graphql functionality: 
- Added create functions to resolver for Media and Celebrity items
- Added the ability to attach/remove a celebrity to the `celebrities` field for a media item (and vice versa for `appearances` with celebrity items)

TODO:
- Add mutators to remove or update a celebrity/media item
- Validate for unique constraints on creates
